### PR TITLE
이미지 관련 후속 개선

### DIFF
--- a/src/main/java/com/wakutabi/controller/TravelsController.java
+++ b/src/main/java/com/wakutabi/controller/TravelsController.java
@@ -32,6 +32,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Controller
 @RequestMapping("/schedule")
@@ -48,6 +49,10 @@ public class TravelsController {
     private final ChatService chatService;
 
     private final TripService tripService;
+    
+    // 중복 요청 방지를 위한 캐시
+    private final ConcurrentHashMap<String, Long> requestCache = new ConcurrentHashMap<>();
+    private static final long REQUEST_TIMEOUT = 5000; // 5초
 
     private final NotificationService notificationService;
 
@@ -261,45 +266,110 @@ public class TravelsController {
     // ...
 
     @PostMapping("/travelupdate")
+    @ResponseBody
     public String updateTravel(@ModelAttribute TravelEditDto dto,
             @ModelAttribute("userId") Long userId,
             @RequestParam(value = "tags", required = false) List<String> tags,
             @RequestParam(value = "images", required = false) List<MultipartFile> images,
             @RequestParam(value = "deletedImageIds", required = false) String deletedImageIds,
             @RequestParam(value = "remainImageIds", required = false) String remainImageIds,
-            Principal principal, RedirectAttributes redirectAttributes) throws IllegalStateException, IOException {
+            Principal principal, RedirectAttributes redirectAttributes) {
 
         if (principal == null) {
-            redirectAttributes.addFlashAttribute("error", "로그인 후 이용 가능합니다.");
-            return "redirect:/login";
+            return "로그인 후 이용 가능합니다.";
         }
-
-        dto.setHostUserId(userId);
-        boolean isUpdated = travelUpdateDeleteService.updateTravelArticle(dto);
-
-        travelEditService.updateTravelTags(dto.getId(), tags);
-
-        // 1. 삭제/유지/추가 이미지 관리
-        List<Long> remainIds = parseIdList(remainImageIds);
-        List<Long> deleteIds = parseIdList(deletedImageIds);
-
-        List<TravelImageDto> allImages = travelImageService.findImagesByTripArticleId(dto.getId());
-        for (TravelImageDto img : allImages) {
-            // 삭제할 이미지: deletedImageIds에 포함되거나, remainImageIds에 없는 경우
-            if (deleteIds.contains(img.getId()) || !remainIds.contains(img.getId())) {
-                travelImageService.deleteImageById(img.getId());
+        
+        // 중복 요청 방지 체크
+        long currentTime = System.currentTimeMillis();
+        
+        // 같은 여행 ID와 사용자에 대한 최근 요청 체크
+        String userTravelKey = dto.getId() + "_" + userId;
+        Long lastRequestTime = requestCache.get(userTravelKey);
+        
+        if (lastRequestTime != null && (currentTime - lastRequestTime) < REQUEST_TIMEOUT) {
+            log.warn("중복 요청 감지 - 사용자: {}, 여행 ID: {}, 마지막 요청: {}ms 전", 
+                userId, dto.getId(), currentTime - lastRequestTime);
+            return "요청이 처리 중입니다. 잠시 후 다시 시도해주세요.";
+        }
+        
+        // 현재 요청 시간 기록
+        requestCache.put(userTravelKey, currentTime);
+        
+        try {
+            log.info("여행 수정 시작 - ID: {}, 새 이미지 개수: {}", dto.getId(), 
+                images != null ? images.size() : 0);
+            
+            dto.setHostUserId(userId);
+            boolean isUpdated = travelUpdateDeleteService.updateTravelArticle(dto);
+            
+            if (!isUpdated) {
+                log.warn("게시글 본문 수정 실패 - ID: {}, 권한 없거나 게시글을 찾을 수 없음", dto.getId());
+                return "게시글 수정 실패! (권한 없거나 게시글을 찾을 수 없습니다)";
             }
-            // 남길 이미지는 아무 것도 하지 않음
-        }
 
-        // 2. 새 이미지 업로드 (추가)
-        travelImageService.addImages(dto.getId(), images);
+            // 태그 업데이트
+            travelEditService.updateTravelTags(dto.getId(), tags);
 
-        if (isUpdated) {
-            return "redirect:/schedule/detail?id=" + dto.getId();
-        } else {
-            redirectAttributes.addFlashAttribute("error", "게시글 수정 실패! (권한 없거나 게시글을 찾을 수 없습니다)");
-            return "redirect:/error";
+            // 1. 삭제/유지 이미지 관리
+            List<Long> remainIds = parseIdList(remainImageIds);
+            List<Long> deleteIds = parseIdList(deletedImageIds);
+            
+            log.info("이미지 관리 - 남길 이미지 ID: {}, 삭제할 이미지 ID: {}", remainIds, deleteIds);
+
+            List<TravelImageDto> allImages = travelImageService.findImagesByTripArticleId(dto.getId());
+            for (TravelImageDto img : allImages) {
+                // 삭제할 이미지: deletedImageIds에 포함되거나, remainImageIds에 없는 경우
+                if (deleteIds.contains(img.getId()) || !remainIds.contains(img.getId())) {
+                    log.info("이미지 삭제 - ID: {}, Path: {}", img.getId(), img.getImagePath());
+                    travelImageService.deleteImageById(img.getId());
+                }
+            }
+
+            // 2. 새 이미지 업로드 (추가) - remainImageIds에 포함되지 않은 새 파일만 업로드
+            if (images != null && !images.isEmpty()) {
+                int actualImageCount = 0;
+                List<MultipartFile> newImages = new java.util.ArrayList<>();
+                for (MultipartFile file : images) {
+                    if (!file.isEmpty()) {
+                        // remainImageIds에 포함된 파일명과 비교하여 중복 추가 방지
+                        boolean isRemain = false;
+                        for (Long remainId : remainIds) {
+                            TravelImageDto remainImg = travelImageService.findImageById(remainId);
+                            if (remainImg != null && file.getOriginalFilename() != null && remainImg.getImagePath() != null && remainImg.getImagePath().contains(file.getOriginalFilename())) {
+                                isRemain = true;
+                                break;
+                            }
+                        }
+                        if (!isRemain) {
+                            newImages.add(file);
+                            actualImageCount++;
+                        }
+                    }
+                }
+                log.info("실제 업로드할 새 이미지 개수: {}", actualImageCount);
+                if (actualImageCount > 0) {
+                    travelImageService.addImages(dto.getId(), newImages);
+                    log.info("새 이미지 업로드 완료");
+                }
+            }
+
+            log.info("여행 수정 완료 - ID: {}", dto.getId());
+            return "수정 완료! ID: " + dto.getId();
+            
+        } catch (Exception e) {
+            log.error("여행 수정 중 오류 발생 - ID: {}, Error: {}", dto.getId(), e.getMessage(), e);
+            return "수정 중 오류가 발생했습니다: " + e.getMessage();
+        } finally {
+            // 처리 완료 후 캐시에서 제거 (5초 후)
+            new Thread(() -> {
+                try {
+                    Thread.sleep(REQUEST_TIMEOUT);
+                    requestCache.remove(userTravelKey);
+                    log.debug("요청 캐시 정리 완료 - {}", userTravelKey);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+            }).start();
         }
     }
 

--- a/src/main/java/com/wakutabi/mapper/TravelImageMapper.java
+++ b/src/main/java/com/wakutabi/mapper/TravelImageMapper.java
@@ -15,7 +15,7 @@ public interface TravelImageMapper {
     // --- 이 메소드를 추가하여 특정 게시글의 이미지 목록을 찾습니다. ---
     List<TravelImageDto> findByTripArticleId(@Param("tripArticleId") Long tripArticleId);
 
-    void deleteImageById(@Param("id") Long id);
+    int deleteImageById(@Param("id") Long id);
 
     TravelImageDto findImageById(@Param("id") Long id);
 

--- a/src/main/java/com/wakutabi/service/TravelImageService.java
+++ b/src/main/java/com/wakutabi/service/TravelImageService.java
@@ -16,6 +16,9 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class TravelImageService {
+    public TravelImageDto findImageById(Long id) {
+        return travelImageMapper.findImageById(id);
+    }
     private final TravelImageMapper travelImageMapper;
 
     public void insertTravelImage(TravelImageDto dto) {
@@ -61,14 +64,24 @@ public class TravelImageService {
         }
     }
 
+    @Transactional
     public void deleteImageById(Long imageId) {
         TravelImageDto img = travelImageMapper.findImageById(imageId);
+        boolean fileDeleted = false;
+        boolean dbDeleted = false;
         if (img != null && img.getImagePath() != null) {
             File file = new File("C:/uploads" + img.getImagePath().replace("/upload", ""));
-            if (file.exists())
-                file.delete();
+            if (file.exists()) {
+                fileDeleted = file.delete();
+                if (!fileDeleted) {
+                    System.err.println("[이미지 삭제 실패] 파일 삭제 실패: " + file.getAbsolutePath());
+                }
+            }
         }
-        travelImageMapper.deleteImageById(imageId);
+    dbDeleted = travelImageMapper.deleteImageById(imageId) > 0;
+        if (!dbDeleted) {
+            System.err.println("[이미지 삭제 실패] DB 레코드 삭제 실패: imageId=" + imageId);
+        }
     }
 
     public void addImages(Long tripArticleId, List<MultipartFile> newImages) throws IllegalStateException, IOException {

--- a/src/main/resources/static/css/travel_detail.css
+++ b/src/main/resources/static/css/travel_detail.css
@@ -89,8 +89,33 @@
 
 /* 개별 이미지 아이템 (모든 경우에 150px 고정 너비 적용) */
 .image-item {
-    width: 150px; /* 모든 이미지의 고정 너비 */
-    flex-shrink: 0; /* 이미지 아이템이 축소되는 것을 방지 */
+	width: 150px !important;
+	height: 150px !important;
+	flex-shrink: 0;
+	overflow: hidden;
+	border-radius: 8px;
+	border: 2px solid var(--primary-color);
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.image-item img {
+	width: 100% !important;
+	height: 100% !important;
+	object-fit: contain !important; /* 비율 유지, 빈 공간은 투명 */
+	transition: transform 0.3s ease;
+	border-radius: 6px;
+	}
+
+.image-item:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+}
+
+.image-item img:hover {
+    transform: scale(1.05); /* 호버 시 약간 확대 */
 }
 
 /* 이미지 갤러리 (수평 스크롤 컨테이너) */

--- a/src/main/resources/static/css/travel_edit.css
+++ b/src/main/resources/static/css/travel_edit.css
@@ -162,16 +162,25 @@
 
 .uploaded-images {
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
-	gap: 10px;
+	grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+	gap: 15px;
 	margin-top: 15px;
 }
 
 .uploaded-image {
 	position: relative;
-	aspect-ratio: 1;
+	width: 120px;
+	height: 120px;
 	border-radius: 8px;
 	overflow: hidden;
+	border: 2px solid var(--primary-color);
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+	transition: transform 0.3s ease;
+}
+
+.uploaded-image:hover {
+	transform: translateY(-2px);
+	box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
 }
 
 .uploaded-image img {

--- a/src/main/resources/static/js/travel_edit.js
+++ b/src/main/resources/static/js/travel_edit.js
@@ -5,6 +5,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const uploadedImages = document.getElementById('uploadedImages');
     const orderNumberInput = document.getElementById('orderNumber');
 
+    // 중복 제출 방지를 위한 전역 플래그
+    let isSubmitting = false;
+
     // 날짜 입력 필드와 에러 메시지 요소
     const startDateInput = document.getElementById('startDate');
     const endDateInput = document.getElementById('endDate');
@@ -251,6 +254,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // ✅ submit 이벤트: 이미지 + 데이터 전송
     document.getElementById("travelRegistrationForm").addEventListener("submit", (e) => {
+        e.preventDefault(); // 기본 폼 제출 방지
+
+        // 중복 제출 방지 - 이미 제출 중이면 무시
+        if (isSubmitting) {
+            console.log("이미 제출 중입니다. 요청이 무시됩니다.");
+            return false;
+        }
 
         if (!validateDates()) {
             endDateInput.focus();
@@ -267,11 +277,22 @@ document.addEventListener('DOMContentLoaded', () => {
             }, 2000);
             return;
         }
+        
+        // 제출 상태를 true로 설정
+        isSubmitting = true;
         // 폼 제출 전에 남아있는 이미지 ID 업데이트
         updateRemainImageIds();
         
         // 유효성 검사를 모두 통과하면 폼 제출
         const form = e.target;
+        
+        // 중복 제출 방지
+        const submitButton = form.querySelector('button[type="submit"]');
+        if (submitButton.disabled) {
+            return; // 이미 제출 중이면 무시
+        }
+        submitButton.disabled = true;
+        submitButton.textContent = '수정 중...';
         
         // ⭐ 예상 비용 필드의 값에서 쉼표 제거 후 전송
         estimatedCostInput.value = estimatedCostInput.value.replace(/,/g, '');
@@ -284,11 +305,26 @@ document.addEventListener('DOMContentLoaded', () => {
         })
         .then(res => res.text())
         .then(msg => {
-            alert("수정 성공!");
+            if (msg.includes("수정 완료")) {
+                alert("수정 성공!");
+                // 상세 페이지로 리다이렉트
+                const travelId = document.querySelector('input[name="id"]').value;
+                window.location.href = `/schedule/detail?id=${travelId}`;
+            } else {
+                alert("수정 실패: " + msg);
+                // 버튼 상태 복구
+                submitButton.disabled = false;
+                submitButton.textContent = '수정하기';
+                isSubmitting = false; // 제출 상태 초기화
+            }
         })
         .catch(err => {
             console.error(err);
             alert("수정 실패!");
+            // 버튼 상태 복구
+            submitButton.disabled = false;
+            submitButton.textContent = '수정하기';
+            isSubmitting = false; // 제출 상태 초기화
         });
     });
 

--- a/src/main/resources/templates/travels/detail.html
+++ b/src/main/resources/templates/travels/detail.html
@@ -10,6 +10,7 @@
     <script defer th:src="@{/js/travel_detail.js}"></script>
     <meta name="_csrf">
     <meta name="_csrf_header">
+
 </head>
 <body>
 <div class="bg-gradient-custom min-vh-100" layout:fragment="content">
@@ -127,7 +128,7 @@
                             <div class="d-flex flex-nowrap overflow-auto g-2 image-gallery justify-content-center"
                                  th:if="${images != null and !#lists.isEmpty(images)}">
                                 <div class="image-item p-1" th:each="image : ${images}">
-                                    <img th:src="${image.imagePath}" class="img-fluid rounded-3" alt="여행 이미지" />
+                                    <img th:src="${image.imagePath}" class="rounded-3" alt="여행 이미지" />
                                 </div>
                             </div>
 

--- a/src/main/resources/templates/travels/edit.html
+++ b/src/main/resources/templates/travels/edit.html
@@ -31,7 +31,8 @@
                 <div class="col-lg-8">
                     <div class="registration-container rounded-4 p-4 shadow-sm">
                         <form id="travelRegistrationForm" action="/schedule/travelupdate"
-                              method="post" enctype="multipart/form-data">
+                              method="post" enctype="multipart/form-data" 
+                              onsubmit="return preventDoubleSubmit(this)">
                             <input type="hidden" name="id" th:value="${travel.id}">
                             <input type="hidden" name="status" th:value="${travel.status}">
 
@@ -289,5 +290,19 @@
         </div>
     </div>
 </div>
+
+<script>
+// 이중 제출 방지 함수
+function preventDoubleSubmit(form) {
+    const submitButton = form.querySelector('button[type="submit"]');
+    if (submitButton.disabled) {
+        return false; // 이미 제출 중이면 차단
+    }
+    submitButton.disabled = true;
+    submitButton.textContent = '수정 중...';
+    return true; // 제출 허용
+}
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
### [중요] 이미지 수정 시 제출에 대한 중복 요청 방지 및 응답 처리 안정화

> 기존에는 테스트용 이미지를 넣을 경우 일부 이미지는 1개를 넣었음에도 2개가 중복 삽입되고
이미지를 전부 지우고 수정하면 수정실패! alert이 발생하는 사태가 있었으나 현재 개선 사항에서는
[전부 삭제 / 일부 삭제 / 삭제 후 추가] 등등 다양한 상황에서도 응답 처리가 정상화되었습니다.
이 부분은 각자 로컬에서 테스트 한번 해보시구 안 되던 잘 되던 말씀 한번 부탁드립니당..
일단 저는 잘 됐음 ^~^

### 상세 페이지 이미지 박스 150x150 기준으로 일관화 및 가운데 정렬 적용

> 150x150 에 충족하지 않는 이미지는 늘려지지 않고 해당 크기 그대로 나오기에
향후 150x150 이상 크기만 넣도록 제한이 필요할 듯 합니다.
150x150으로 한 이유는 딱히 없습니다 크기야 뭐 그냥 나중에 조정 바로 가능하니까...!


