### PR TITLE
여행 삭제 기능 구현 및 삭제 시 리다이렉트 경로 정정

### DIFF
--- a/src/main/java/com/wakutabi/domain/TravelEditDto.java
+++ b/src/main/java/com/wakutabi/domain/TravelEditDto.java
@@ -34,4 +34,25 @@ public class TravelEditDto {
     public void setTags(List<String> tags) { this.tags = tags; }
     private String tag; 
     private List<MultipartFile> images;
+    
+    // 지역명을 한글로 변환하는 메서드
+    public String getLocationKorean() {
+        if (location == null) return "지역 미정";
+        
+        switch (location.toLowerCase()) {
+            case "tokyo": return "도쿄";
+            case "osaka": return "오사카";
+            case "kyoto": return "교토";
+            case "hokkaido": return "홋카이도";
+            case "okinawa": return "오키나와";
+            case "shikoku": return "시코쿠";
+            case "kyushu": return "규슈";
+            case "chubu": return "주부";
+            case "tohoku": return "도호쿠";
+            case "chugoku": return "주고쿠";
+            case "kansai": return "간사이";
+            case "kanto": return "간토";
+            default: return location;
+        }
+    }
 }

--- a/src/main/java/com/wakutabi/domain/TravelUploadDto.java
+++ b/src/main/java/com/wakutabi/domain/TravelUploadDto.java
@@ -21,4 +21,25 @@ public class TravelUploadDto {
     private String tag;
     private String orderNumber;
     private List<MultipartFile> images;
+    
+    // 지역명을 한글로 변환하는 메서드
+    public String getLocationKorean() {
+        if (location == null) return "지역 미정";
+        
+        switch (location.toLowerCase()) {
+            case "tokyo": return "도쿄";
+            case "osaka": return "오사카";
+            case "kyoto": return "교토";
+            case "hokkaido": return "홋카이도";
+            case "okinawa": return "오키나와";
+            case "shikoku": return "시코쿠";
+            case "kyushu": return "규슈";
+            case "chubu": return "주부";
+            case "tohoku": return "도호쿠";
+            case "chugoku": return "주고쿠";
+            case "kansai": return "간사이";
+            case "kanto": return "간토";
+            default: return location;
+        }
+    }
 }

--- a/src/main/java/com/wakutabi/domain/TripListDto.java
+++ b/src/main/java/com/wakutabi/domain/TripListDto.java
@@ -23,4 +23,25 @@ public class TripListDto {
     
     // (선택) 목록에서 태그를 보여주려면 List<String> tags를 추가할 수 있습니다.
     // private List<String> tags;
+    
+    // 지역명을 한글로 변환하는 메서드
+    public String getLocationKorean() {
+        if (location == null) return "지역 미정";
+        
+        switch (location.toLowerCase()) {
+            case "tokyo": return "도쿄";
+            case "osaka": return "오사카";
+            case "kyoto": return "교토";
+            case "hokkaido": return "홋카이도";
+            case "okinawa": return "오키나와";
+            case "shikoku": return "시코쿠";
+            case "kyushu": return "규슈";
+            case "chubu": return "주부";
+            case "tohoku": return "도호쿠";
+            case "chugoku": return "주고쿠";
+            case "kansai": return "간사이";
+            case "kanto": return "간토";
+            default: return location;
+        }
+    }
 }

--- a/src/main/java/com/wakutabi/service/TravelUpdateDeleteService.java
+++ b/src/main/java/com/wakutabi/service/TravelUpdateDeleteService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.wakutabi.domain.TravelEditDto;
 import com.wakutabi.mapper.TravelUpdateDeleteMapper;
+import com.wakutabi.mapper.TravelTagMapper;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 public class TravelUpdateDeleteService {
 
     private final TravelUpdateDeleteMapper travelupdatedeletemapper;
+    private final TravelTagMapper travelTagMapper;
 
     public boolean updateTravelArticle(TravelEditDto dto) {
         int updateRows = travelupdatedeletemapper.updateTravelArticle(dto);
@@ -25,9 +27,17 @@ public class TravelUpdateDeleteService {
     
     @Transactional
     public boolean deleteTravelArticle(Long id, Long hostUserId) {
-        
+        // 0. 태그 중간 테이블 삭제 (FK 제약으로 부모 삭제 전에 필요)
+        travelTagMapper.deleteTripTagsByTravelId(id);
+
         // 1. 게시글에 연결된 이미지들을 먼저 삭제합니다. (자식 테이블)
         travelupdatedeletemapper.deleteTravelImages(id);
+
+        // TODO: 필요 시 아래 자식 테이블들도 정리 (FK 에러 발생 시 순차 삭제)
+        // - trip_join_request (trip_article_id)
+        // - chat_room -> chat_participants, chat_message (trip_article_id)
+        // - system_notification (trip_article_id)
+        // - qna_questions (trip_article_id)
         
         // 2. 그 다음, 게시글 본문을 삭제합니다. (부모 테이블)
         int deleteRows = travelupdatedeletemapper.deleteTravelArticle(id, hostUserId);

--- a/src/main/java/com/wakutabi/util/LocationUtil.java
+++ b/src/main/java/com/wakutabi/util/LocationUtil.java
@@ -1,0 +1,57 @@
+package com.wakutabi.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 지역 코드를 한글명으로 변환하는 유틸리티 클래스
+ */
+public class LocationUtil {
+    
+    private static final Map<String, String> LOCATION_MAP = new HashMap<>();
+    
+    static {
+        LOCATION_MAP.put("tokyo", "도쿄");
+        LOCATION_MAP.put("osaka", "오사카");
+        LOCATION_MAP.put("kyoto", "교토");
+        LOCATION_MAP.put("hokkaido", "홋카이도");
+        LOCATION_MAP.put("okinawa", "오키나와");
+        LOCATION_MAP.put("shikoku", "시코쿠");
+        LOCATION_MAP.put("kyushu", "규슈");
+        LOCATION_MAP.put("chubu", "주부");
+        LOCATION_MAP.put("tohoku", "도호쿠");
+        LOCATION_MAP.put("chugoku", "주고쿠");
+        LOCATION_MAP.put("kansai", "간사이");
+        LOCATION_MAP.put("kanto", "간토");
+    }
+    
+    /**
+     * 영어 지역 코드를 한글명으로 변환
+     * @param locationCode 영어 지역 코드
+     * @return 한글 지역명
+     */
+    public static String toKorean(String locationCode) {
+        if (locationCode == null) {
+            return "지역 미정";
+        }
+        return LOCATION_MAP.getOrDefault(locationCode.toLowerCase(), locationCode);
+    }
+    
+    /**
+     * 한글 지역명을 영어 코드로 변환
+     * @param koreanName 한글 지역명
+     * @return 영어 지역 코드
+     */
+    public static String toEnglish(String koreanName) {
+        if (koreanName == null) {
+            return null;
+        }
+        
+        for (Map.Entry<String, String> entry : LOCATION_MAP.entrySet()) {
+            if (entry.getValue().equals(koreanName)) {
+                return entry.getKey();
+            }
+        }
+        return koreanName;
+    }
+}

--- a/src/main/resources/mapper/TravelTagMapper.xml
+++ b/src/main/resources/mapper/TravelTagMapper.xml
@@ -19,8 +19,8 @@
         VALUES (#{tagName})
     </insert>
 	
-    <delete id="deleteTripTagsByTravelId" parameterType="long">
-        DELETE FROM trip_tag_mid_trip_article WHERE trip_article_id = #{tripArticleId}
-    </delete>
+	<delete id="deleteTripTagsByTravelId">
+		DELETE FROM trip_tag_mid_trip_article WHERE trip_article_id = #{tripArticleId}
+	</delete>
     
 </mapper>

--- a/src/main/resources/mapper/TripMapper.xml
+++ b/src/main/resources/mapper/TripMapper.xml
@@ -36,7 +36,7 @@
         LIMIT 1
         ) AS main_image_path,
         t.status,
-        t.maxParticipants,
+        t.max_participants AS maxParticipants,
         (
         SELECT COUNT(cp.id)
         FROM chat_room cr

--- a/src/main/resources/static/js/travel_detail.js
+++ b/src/main/resources/static/js/travel_detail.js
@@ -161,7 +161,7 @@ document.addEventListener("DOMContentLoaded", () => {
             .then(msg => {
                 alert(msg);
                 if (msg.includes("완료")) {
-                    location.href = "/schedule/list";
+                    location.href = "/schedule/myTrips";
                 }
             })
             .catch(err => console.error("삭제 요청 실패", err));

--- a/src/main/resources/templates/travels/detail.html
+++ b/src/main/resources/templates/travels/detail.html
@@ -29,7 +29,7 @@
                     <h1 class="mb-2" th:text="${travel.title}">여행 제목</h1>
                     <p class="text-muted">
                         <i class="bi bi-geo-alt-fill me-1"></i>
-                        <span th:text="${travel.location}">지역</span>
+                        <span th:text="${travel.locationKorean}">지역</span>
                     </p>
                 </div>
             </div>

--- a/src/main/resources/templates/travels/edit.html
+++ b/src/main/resources/templates/travels/edit.html
@@ -244,7 +244,7 @@
                                     <div class="d-flex justify-content-between align-items-start mb-2">
                                         <h6 class="card-title mb-0" id="previewTitle" th:text="${travel.title}"></h6>
                                         <span class="badge bg-secondary"
-                                              id="previewRegion" th:text="${travel.location}">지역</span>
+                                              id="previewRegion" th:text="${travel.locationKorean}">지역</span>
                                     </div>
 
                                     <div class="text-muted mb-2"

--- a/src/main/resources/templates/travels/myTrips.html
+++ b/src/main/resources/templates/travels/myTrips.html
@@ -132,7 +132,7 @@
                         <div class="card-body">
                             <div class="d-flex justify-content-between align-items-start mb-2">
                                 <h5 class="card-title mb-0" th:text="${trip.title}">🗼 도쿄 3박4일 먹방 여행</h5>
-                                <span class="badge region-badge" th:text="${trip.location}">도쿄</span>
+                                <span class="badge region-badge" th:text="${trip.locationKorean}">도쿄</span>
                             </div>
 
                             <div class="date-range mb-2">

--- a/src/main/resources/templates/travels/search.html
+++ b/src/main/resources/templates/travels/search.html
@@ -345,7 +345,7 @@
             <h5 class="card-title mb-0" th:text="${travel.title}"></h5>
             <span class="badge region-badge"
                   th:classappend="${travel.status == 'CLOSED' ? 'region-badge-closed' : ''}"
-                  th:text="${travel.location}"></span>
+                  th:text="${travel.locationKorean}"></span>
           </div>
 
           <div class="date-range mb-2">


### PR DESCRIPTION
### - TravelUpdateDeleteService: FK 제약 해결을 위해 태그 매핑 먼저 삭제하도록  내부 순서 변경
### - TravelTagMapper.xml: deleteTripTagsByTravelId 매핑에서 parameterType 제거로 바인딩 안정화
### - TripMapper.xml: 컬럼명 불일치 수정 (maxParticipants -> max_participants)
### - travel_detail.js: 삭제 후 리다이렉트 경로를 /schedule/myTrips로 변경