### PR TITLE
feat: 여행 상세페이지 필드 추가, 현재 참가자 동적 반영 및 레이아웃 개선

### DIFF
--- a/src/main/java/com/wakutabi/controller/TravelsController.java
+++ b/src/main/java/com/wakutabi/controller/TravelsController.java
@@ -367,6 +367,9 @@ public class TravelsController {
         // 4. 채팅방 ID 조회
         Long chatRoomId = chatService.chatRoomFindByTripArticleId(travel.getId());
 
+        // 5. 채팅 참가자 수 조회하여 DTO에 세팅
+        travel.setCurrentParticipants(chatService.getCurrentParticipants(travel.getId()));
+
 
         // 5. Model에 모든 정보 담기
         model.addAttribute("travel", travel);

--- a/src/main/java/com/wakutabi/domain/TravelEditDto.java
+++ b/src/main/java/com/wakutabi/domain/TravelEditDto.java
@@ -17,6 +17,7 @@ public class TravelEditDto {
     private LocalDate startDate;
     private LocalDate recruitEndDate;   // 모집종료날짜
     private LocalDate endDate;
+    private int currentParticipants;    // 현재 참가자 수(호스트 포함)
     private Integer maxParticipants;
     private String ageLimit;
     private String genderLimit;
@@ -29,7 +30,6 @@ public class TravelEditDto {
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
     private String mainImagePath;
- // TravelEditDto.java 에 List<String> tags 추가
     private List<String> tags;
     public List<String> getTags() { return tags; }
     public void setTags(List<String> tags) { this.tags = tags; }

--- a/src/main/java/com/wakutabi/mapper/ChatParticipantsMapper.java
+++ b/src/main/java/com/wakutabi/mapper/ChatParticipantsMapper.java
@@ -18,4 +18,6 @@ public interface ChatParticipantsMapper {
 	int updateStatusToCanceled(@Param("list") List<Long> canceledTripIds);
 	// 여행 취소, 종료되면 참가자 상태 '완료'로 변경
 	int updateStatusToCompleted(@Param("list") List<Long> endedTripIds);
+	// 여행별 ACTIVE 참가자 수 반환
+	int countActiveParticipantsByTripArticleId(@Param("tripArticleId") Long tripArticleId);
 }

--- a/src/main/java/com/wakutabi/service/ChatParticipantsService.java
+++ b/src/main/java/com/wakutabi/service/ChatParticipantsService.java
@@ -17,4 +17,8 @@ public class ChatParticipantsService {
 	public void addUserToChatParticipants(Long chatRoomId, Long applicantUserId){
 		chatParticipantsMapper.addUserToChatParticipants(chatRoomId, applicantUserId);
 	}
+	// 여행별 ACTIVE 참가자 수 반환
+	public int countActiveParticipantsByTripArticleId(Long tripArticleId) {
+		return chatParticipantsMapper.countActiveParticipantsByTripArticleId(tripArticleId);
+	}
 }

--- a/src/main/java/com/wakutabi/service/ChatService.java
+++ b/src/main/java/com/wakutabi/service/ChatService.java
@@ -46,4 +46,8 @@ public class ChatService {
 	public Long chatRoomFindByTripArticleId(Long tripArticleId) {
 		return chatMapper.chatRoomFindByTripArticleId(tripArticleId);
 	}
+	// 여행별 ACTIVE 참가자 수 반환
+	public int getCurrentParticipants(Long tripArticleId) {
+		return chatParticipantsService.countActiveParticipantsByTripArticleId(tripArticleId);
+	}
 }

--- a/src/main/resources/mapper/ChatParticipantsMapper.xml
+++ b/src/main/resources/mapper/ChatParticipantsMapper.xml
@@ -48,4 +48,11 @@
         )
         AND status = 'ACTIVE'
     </update>
+    <!-- 여행별 ACTIVE 참가자 수 반환 -->
+    <select id="countActiveParticipantsByTripArticleId" parameterType="java.lang.Long" resultType="int">
+        SELECT COUNT(*) FROM chat_participants cp
+        JOIN chat_room cr ON cp.chat_room_id = cr.id
+        WHERE cr.trip_article_id = #{tripArticleId}
+        AND cp.status = 'ACTIVE'
+    </select>
 </mapper>

--- a/src/main/resources/templates/travels/detail.html
+++ b/src/main/resources/templates/travels/detail.html
@@ -101,7 +101,7 @@
                                     <span class="badge bg-secondary-subtle text-dark">
                                         <i class="bi bi-people me-1"></i> <strong>인원</strong>
                                     </span>
-                                    <p class="mb-0 mt-1" th:text="'3/' + ${travel.maxParticipants} + '명'"></p>
+                                    <p class="mb-0 mt-1" th:text="${travel.currentParticipants} + '/' + ${travel.maxParticipants} + '명'"></p>
                                 </div>
                             
                                 <div class="col mb-2">

--- a/src/main/resources/templates/travels/detail.html
+++ b/src/main/resources/templates/travels/detail.html
@@ -33,7 +33,7 @@
 
             <div class="row">
                 <!-- 여행 정보 카드 -->
-                <div class="col-lg-8">
+                <div class="col-lg-9">
                     <div class="card shadow-sm rounded-4 mb-4">
                         <div class="card-body p-4">
 
@@ -55,31 +55,40 @@
                             <!-- 여행 세부 정보 -->
                             <div class="row text-center mb-3">
     
-                                <div class="col-6 col-md-2 mb-2">
+                                <div class="col mb-2">
+                                    <span class="badge bg-warning-subtle text-dark">
+                                        <i class="bi bi-alarm me-1"></i> <strong>모집마감</strong>
+                                    </span>
+                                    <p class="mb-0 mt-1"
+                                       th:text="${#temporals.format(travel.recruitEndDate, 'yyyy. MM. dd')}">
+                                    </p>
+                                </div>
+    
+                                <div class="col mb-2">
                                     <span class="badge bg-secondary-subtle text-dark">
                                         <i class="bi bi-calendar me-1"></i> <strong>일정</strong>
                                     </span>
-                                    <p class="mb-0 mt-1 fs-6"
-                                       th:utext="${#temporals.format(travel.startDate, 'yyyy. MM. dd')} + '<br/>~ ' + ${#temporals.format(travel.EndDate, 'yyyy. MM. dd')}">
+                                    <p class="mb-0 mt-1"
+                                       th:text="${#temporals.format(travel.startDate, 'yyyy. MM. dd')} + ' ~ ' + ${#temporals.format(travel.EndDate, 'yyyy. MM. dd')}">
                                     </p>
                                 </div>
                             
-                                <div class="col-6 col-md-2 mb-2">
+                                <div class="col mb-2">
                                     <span class="badge bg-secondary-subtle text-dark">
-                                        <i class="bi bi-currency-yen me-1"></i> <strong>예상 요금</strong>
+                                        <i class="bi bi-currency-yen me-1"></i> <strong>예상 비용</strong>
                                     </span>
                                     <p class="mb-0 mt-1"
-                                       th:text="${#numbers.formatInteger(travel.estimatedCost, 3, 'COMMA')} + '원'"></p>
+                                       th:text="${#numbers.formatInteger(travel.estimatedCost, 3, 'COMMA')} + '엔'"></p>
                                 </div>
                             
-                                <div class="col-6 col-md-2 mb-2">
+                                <div class="col mb-2">
                                     <span class="badge bg-secondary-subtle text-dark">
                                         <i class="bi bi-person-circle me-1"></i> <strong>선호 연령</strong>
                                     </span>
                                     <p class="mb-0 mt-1" th:text="${travel.ageLimitKorean}"></p>
                                 </div>
                             
-                                <div class="col-6 col-md-2 mb-2">
+                                <div class="col mb-2">
                                     <span class="badge bg-secondary-subtle text-dark">
                                         <i class="bi bi-gender-ambiguous me-1"></i> <strong>성별 제한</strong>
                                     </span>
@@ -88,14 +97,14 @@
                                     </p>
                                 </div>
                             
-                                <div class="col-6 col-md-2 mb-2">
+                                <div class="col mb-2">
                                     <span class="badge bg-secondary-subtle text-dark">
                                         <i class="bi bi-people me-1"></i> <strong>인원</strong>
                                     </span>
                                     <p class="mb-0 mt-1" th:text="'3/' + ${travel.maxParticipants} + '명'"></p>
                                 </div>
                             
-                                <div class="col-6 col-md-2 mb-2">
+                                <div class="col mb-2">
                                     <span class="badge bg-success-subtle text-dark">
                                         <i class="bi bi-person-plus me-1"></i> <strong>상태</strong>
                                     </span>
@@ -129,7 +138,7 @@
                     </div>
                 </div>
 
-                <div class="col-lg-4">
+                <div class="col-lg-3">
                     <form id="joinForm" th:action="@{/join-request}" method="post">
                         <input type="hidden" name="tripArticleId" th:value="${travel.id}">
                         <input type="hidden" name="hostUserId" th:value="${travel.hostUserId}">


### PR DESCRIPTION
### 현재 참가자는 DB상 컬럼이 존재하지 않고 채팅 참가자로 읽어와서 반영하도록 하였습니다.

[TravelEditDto]
- 현재 참가자 수 반영을 위한 필드(currentParticipants) 추가
- 참가자 수를 나타내며, DB의 컬럼에서 매핑되지 않고 신청 후 채팅방 참가자 수를 기준으로 설정됨

[TravelsController]
- 상세 페이지에서 현재 사용자의 여행 참여 상태를 반영하도록 수정

[ChatParticipantsMapper & ChatParticipantsService & ChatService]
- 현재 참가자 수를 반환하는 메서드 추가

[ChatParticipantsMapper.xml]
- 현재 참가자 수를 조회하는 SQL 쿼리 추가

[detail.html]
- 모집마감일 정보 추가 (주황색 배지로 강조)
- 카드 레이아웃 비율 조정(8:4 → 9:3)하여 세부 정보 한 줄 표시
- 좌측 패널: 현재 참가자 수 및 참가 상태에 따라 동적 변경 구현 완료

> 우측 패널은 우선 이번꺼 Merge시키고 하드코딩 부분 제거 후 동적 데이터로 변경하겠습니다.