### PR TITLE
feat: 여행 상세 페이지 우측 패널 하드코딩 제거 및 작성자, 참여자 정보 동적 표시 기능 구현

### DIFF
--- a/src/main/java/com/wakutabi/controller/TravelsController.java
+++ b/src/main/java/com/wakutabi/controller/TravelsController.java
@@ -8,6 +8,8 @@ import com.wakutabi.configure.FilePathConfig;
 import com.wakutabi.domain.ImageOrderDto;
 import com.wakutabi.domain.NotificationDto;
 import com.wakutabi.domain.ParticipantDto;
+import com.wakutabi.mapper.ParticipantMapper;
+import com.wakutabi.mapper.UserMapper;
 import com.wakutabi.domain.RequestStatusDto;
 import com.wakutabi.domain.TravelEditDto;
 import com.wakutabi.domain.TravelImageDto;
@@ -64,6 +66,8 @@ public class TravelsController {
     private final ChatService chatService;
     private final ChatParticipantsService chatParticipantsService;
     private final TripService tripService;
+    private final ParticipantMapper participantMapper;
+    private final UserMapper userMapper;
     
     // 중복 요청 방지를 위한 캐시
     private final ConcurrentHashMap<String, Long> requestCache = new ConcurrentHashMap<>();
@@ -370,12 +374,30 @@ public class TravelsController {
         // 5. 채팅 참가자 수 조회하여 DTO에 세팅
         travel.setCurrentParticipants(chatService.getCurrentParticipants(travel.getId()));
 
+        // 6. 작성자 정보 및 참여자 목록 조회
+        ParticipantDto author = null;
+        List<ParticipantDto> participants = new ArrayList<>();
+        try {
+            List<ParticipantDto> all = participantMapper.findParticipantsByTripId(travel.getId());
+            if (all != null && !all.isEmpty()) {
+                // 첫 번째는 호스트(작성자)로 가정
+                author = all.get(0);
+                if (all.size() > 1) {
+                    participants = all.subList(1, all.size());
+                }
+            }
+        } catch (Exception ex) {
+            log.warn("참여자 목록 조회 중 오류", ex);
+        }
+
 
         // 5. Model에 모든 정보 담기
         model.addAttribute("travel", travel);
         model.addAttribute("images", images);
         model.addAttribute("isOwner", isOwner);
         model.addAttribute("chatRoomId", chatRoomId);
+        model.addAttribute("author", author);
+        model.addAttribute("participants", participants);
         
 
         return "travels/detail";

--- a/src/main/resources/templates/travels/detail.html
+++ b/src/main/resources/templates/travels/detail.html
@@ -145,10 +145,10 @@
                         <input type="hidden" name="chatRoomId" th:value="${chatRoomId}">
                         <div class="card shadow-sm rounded-4 p-4 sticky-top" style="top: 20px">
                             <div class="text-center mb-3">
-                            <img src="/image/testuser.jpg" alt="프로필 이미지" class="rounded-circle mb-2"
+                            <img th:src="${author != null && author.imagePath != null ? author.imagePath : '/image/testuser.jpg'}" alt="프로필 이미지" class="rounded-circle mb-2"
                                  style="width: 80px; height: 80px; object-fit: cover" />
                             <h5 class="mb-0">여행 작성자</h5>
-                            <small class="text-muted">@김민지</small>
+                            <small class="text-muted" th:text="${author != null && author.nickname != null ? '' + author.nickname : ''}"></small>
                             </div>
                             <div class="d-grid mb-3">
                                 <button id="joinBtn" type="button" class="btn btn-wakutabi-primary btn-lg">참가 신청하기</button>
@@ -157,10 +157,11 @@
                             <hr />
                             <h6 class="fw-bold mb-3">참여자 목록</h6>
                             <ul class="list-unstyled">
-                                <li class="d-flex align-items-center mb-2">
-                                    <img src="/image/testuser.jpg" style="width:55px; height:55px;" alt="참여자" class="participant-avatar" />
-                                    <span class="ms-2">박지훈</span>
+                                <li class="d-flex align-items-center mb-2" th:each="participant : ${participants}">
+                                    <img th:src="${participant.imagePath != null ? participant.imagePath : '/image/testuser.jpg'}" style="width:55px; height:55px;" alt="참여자" class="participant-avatar" />
+                                    <span class="ms-2" th:text="${participant.nickname}">참여자</span>
                                 </li>
+                                <li th:if="${#lists.isEmpty(participants)}" class="text-muted text-center">참여자가 없습니다.</li>
                             </ul>
                         </div>
                     </form>


### PR DESCRIPTION
[TravelsController]
- 작성자 정보와 참여자 목록을 동적으로 불러와 뷰에 전달하는 기능 추가

[detail.html]
- 우측 패널 내 작성자 프로필 이미지 및 닉네임, 참여자 목록을 동적으로 표시하도록 수정
- 작성자 정보가 없을 경우 기본 이미지와 빈 닉네임 처리
- 참여자 목록이 없을 경우 '참여자가 없습니다.' 메시지 표시 기능 추가