### PR TITLE
내 여행 관리 페이지 기능 개선_v2

### DIFF
--- a/src/main/java/com/wakutabi/domain/TripListDto.java
+++ b/src/main/java/com/wakutabi/domain/TripListDto.java
@@ -28,6 +28,8 @@ public class TripListDto {
     
     // (선택) 목록에서 태그를 보여주려면 List<String> tags를 추가할 수 있습니다.
     private List<String> tags;
+    private LocalDate recruitEndDate;
+    private String content;
     
     // 지역명을 한글로 변환하는 메서드
     public String getLocationKorean() {

--- a/src/main/java/com/wakutabi/service/TravelEditService.java
+++ b/src/main/java/com/wakutabi/service/TravelEditService.java
@@ -53,15 +53,15 @@ public class TravelEditService {
             "시코쿠", "Shikoku",
             "규슈", "Kyushu",
             "오키나와", "Okinawa"
-            // 여기에 추가적인 지역 매핑을 넣으세요.
-        );
-    
+    // 여기에 추가적인 지역 매핑을 넣으세요.
+    );
+
     // 복합 검색 및 필터링 기능을 위한 메서드
     public List<TravelEditDto> findFilteredTravels(String query, Integer minPrice, Integer maxPrice,
             String region, LocalDateTime startDate, LocalDateTime endDate,
             List<String> tags, List<String> groupSize, String status, int offset, int size) {
 
-    	String translatedQuery = null;
+        String translatedQuery = null;
         if (query != null && !query.isEmpty()) {
             String lowerQuery = query.toLowerCase();
             // 쿼리가 매핑 맵에 있으면 번역된 값을 설정
@@ -69,7 +69,7 @@ public class TravelEditService {
                 translatedQuery = KOREAN_TO_ROMANIZED.get(lowerQuery);
             }
         }
-        
+
         Map<String, Object> params = new HashMap<>();
         params.put("query", query);
         params.put("translatedQuery", translatedQuery); // ⬅️ 번역된 쿼리 추가
@@ -87,42 +87,41 @@ public class TravelEditService {
         // 1️⃣ Mapper에서 여행 게시글 조회
         List<TravelEditDto> travels = travelEditmapper.selectTravels(params);
 
-        // 2️⃣ 각 여행 게시글에 대한 태그 조회 후 DTO에 세팅
-        for (TravelEditDto travel : travels) {
-            List<String> tagList = travelTagMapper.findTagsByTripArticleId(travel.getId());
-            travel.setTags(tagList);
-            
-         // 3. 맵을 매퍼로 전달
-            return travelEditmapper.selectTravels(params); // ⬅️ selectTravels 시그니처가 Map을 받도록 가정
+        // null 체크 추가
+        if (travels != null) {
+            // 2️⃣ 각 여행 게시글에 대한 태그 조회 후 DTO에 세팅
+            for (TravelEditDto travel : travels) {
+                List<String> tagList = travelTagMapper.findTagsByTripArticleId(travel.getId());
+                travel.setTags(tagList);
+            }
         }
-
-        return travels;
+        return travels; // 3️⃣ 완성된 DTO 리스트 반환
     }
 
-        public int countFilteredTravels(String query, Integer minPrice, Integer maxPrice,
-                String region, LocalDateTime startDate, LocalDateTime endDate,
-                List<String> tags, List<String> groupSize, String status) {
+    public int countFilteredTravels(String query, Integer minPrice, Integer maxPrice,
+            String region, LocalDateTime startDate, LocalDateTime endDate,
+            List<String> tags, List<String> groupSize, String status) {
 
-        	String translatedQuery = null;
-            if (query != null && !query.isEmpty()) {
-                String lowerQuery = query.toLowerCase();
-                // KOREAN_TO_ROMANIZED 맵에서 번역된 값을 가져옵니다.
-                translatedQuery = KOREAN_TO_ROMANIZED.getOrDefault(lowerQuery, null);
-            }
-            
-            Map<String, Object> params = new HashMap<>();
-            params.put("query", query);
-            params.put("translatedQuery", translatedQuery); // ⬅️ Map에 포함
-            params.put("minPrice", minPrice);
-            params.put("maxPrice", maxPrice);
-            params.put("region", region);
-            params.put("startDate", startDate);
-            params.put("endDate", endDate);
-            params.put("tagsList", tags);
-            params.put("groupSize", groupSize);
-            params.put("status", status);
+        String translatedQuery = null;
+        if (query != null && !query.isEmpty()) {
+            String lowerQuery = query.toLowerCase();
+            // KOREAN_TO_ROMANIZED 맵에서 번역된 값을 가져옵니다.
+            translatedQuery = KOREAN_TO_ROMANIZED.getOrDefault(lowerQuery, null);
+        }
 
-            return travelEditmapper.countFilteredTravels(params);
+        Map<String, Object> params = new HashMap<>();
+        params.put("query", query);
+        params.put("translatedQuery", translatedQuery); // ⬅️ Map에 포함
+        params.put("minPrice", minPrice);
+        params.put("maxPrice", maxPrice);
+        params.put("region", region);
+        params.put("startDate", startDate);
+        params.put("endDate", endDate);
+        params.put("tagsList", tags);
+        params.put("groupSize", groupSize);
+        params.put("status", status);
+
+        return travelEditmapper.countFilteredTravels(params);
     }
 
     @Transactional // ⭐트랜잭션 처리를 위해 어노테이션을 붙입니다.

--- a/src/main/resources/mapper/TripMapper.xml
+++ b/src/main/resources/mapper/TripMapper.xml
@@ -8,6 +8,8 @@
         <result property="location" column="location"/>
         <result property="startDate" column="start_date"/>
         <result property="endDate" column="end_date"/>
+        <result property="recruitEndDate" column="recruit_end_date"/>
+        <result property="content" column="content"/>
         <result property="mainImagePath" column="main_image_path"/>
         <result property="status" column="status"/>
         <result property="currentParticipants" column="current_participants_count"/> 
@@ -36,6 +38,8 @@
         t.location,
         t.start_date,
         t.end_date,
+        t.recruit_end_date,
+        t.content,
         (
         SELECT tai.image_path
         FROM trip_article_image tai
@@ -115,6 +119,8 @@
             t.location,
             t.start_date,
             t.end_date,
+            t.recruit_end_date,
+            t.content,
             (
                 SELECT tai.image_path
                 FROM trip_article_image tai

--- a/src/main/resources/static/js/travel.js
+++ b/src/main/resources/static/js/travel.js
@@ -86,8 +86,8 @@ $(document).ready(function () {
     btn.addEventListener("click", showMore);
   }
 
-  initLoadMore("my-registered-trips", "loadMoreRegistered", 5);
-  initLoadMore("my-applied-trips", "loadMoreApplied", 5);
+  initLoadMore("my-registered-trips", "loadMoreRegistered", 4);
+  initLoadMore("my-applied-trips", "loadMoreApplied", 4);
 
   // ✅ 신청 관리 버튼 (동적 요소 대응)
   $(document).on("click", ".btn-manage", function () {

--- a/src/main/resources/templates/travels/myTrips.html
+++ b/src/main/resources/templates/travels/myTrips.html
@@ -29,7 +29,7 @@
                     <!-- Schedule Cards -->
                     <div class="row g-4">
                         <!-- Schedule Card 1 -->
-                        <h3 id="my-registered-trips">등록한 여행</h3>
+                        <h3>등록한 여행</h3>
                         <section id="my-registered-trips" class="mb-5">
                             <div th:if="${#lists.isEmpty(registeredTrips)}" class="alert alert-info" role="alert">
                                 아직 등록한 여행 일정이 없습니다.
@@ -55,8 +55,13 @@
                                                         ~
                                                         <span th:text="${#temporals.format(trip.endDate, 'yyyy년 MM월 dd일')}"></span>
                                                     </div>
-                                                    <p class="card-text text-muted mb-3">
-                                                    여행 요약이나 간단한 내용이 표시될 공간입니다.
+                                                    <div class="date-range mb-2">
+                                                        <i class="bi bi-calendar-check me-1"></i>
+                                                        <span>모집 마감: </span>
+                                                        <span th:text="${#temporals.format(trip.recruitEndDate, 'yyyy년 MM월 dd일')}"></span>
+                                                    </div>
+                                                    <p class="card-text text-muted mb-3"
+                                                        th:text="${#strings.abbreviate(trip.content, 100)}">
                                                     </p>
                                                     <div class="mb-3">
                                                         <span th:each="tag : ${trip.tags}" class="badge schedule-tag me-1" th:text="${tag}"></span>
@@ -66,9 +71,8 @@
                                                             <div class="participants-info p-2 rounded">
                                                                 <div class="status-info js-participants-toggle">
                                                                     <i class="bi bi-people-fill me-1"></i>
-                                                                    <span
-                                                                    th:text="|참여 중 ${trip.currentParticipants}/${trip.maxParticipants}명|">
-                                                                    </span>
+                                                                    <strong th:text="${trip.currentParticipants} + '/' + ${trip.maxParticipants} + '명'"></strong>
+                                                                    참여 중
                                                                 </div>
                                                             </div>
                                                         </div>
@@ -102,7 +106,7 @@
                             <i class="bi bi-arrow-down-circle me-2"></i> 여행 더보기
                         </button>
                         <!--Schedule Card 2  -->
-                        <h3 id="my-applied-trips">신청한 여행</h3>
+                        <h3>신청한 여행</h3>
                         <section id="my-applied-trips" class="mb-5">
                             <div th:if="${#lists.isEmpty(appliedTrips)}" class="alert alert-info" role="alert">
                                 아직 신청한 여행 일정이 없습니다.
@@ -129,8 +133,13 @@
                                                         ~
                                                         <span th:text="${#temporals.format(trip.endDate, 'yyyy년 MM월 dd일')}"></span>
                                                     </div>
-                                                    <p class="card-text text-muted mb-3">
-                                                    여행 요약이나 간단한 내용이 표시될 공간입니다.
+                                                    <div class="date-range mb-2">
+                                                        <i class="bi bi-calendar-check me-1"></i>
+                                                        <span>모집 마감: </span>
+                                                        <span th:text="${#temporals.format(trip.recruitEndDate, 'yyyy년 MM월 dd일')}"></span>
+                                                    </div>
+                                                    <p class="card-text text-muted mb-3"
+                                                        th:text="${#strings.abbreviate(trip.content, 100)}">
                                                     </p>
                                                     <div class="mb-3">
                                                         <span th:each="tag : ${trip.tags}" class="badge schedule-tag me-1" th:text="${tag}"></span>
@@ -140,8 +149,8 @@
                                                             <div class="participants-info p-2 rounded">
                                                                 <div class="status-info js-participants-toggle">
                                                                     <i class="bi bi-people-fill me-1"></i>
-                                                                    <span th:text="|참여 중 ${trip.currentParticipants}/${trip.maxParticipants}명|">
-                                                                    </span>
+                                                                    <strong th:text="${trip.currentParticipants} + '/' + ${trip.maxParticipants} + '명'"></strong>
+                                                                    참여 중
                                                                 </div>
                                                             </div>
                                                         </div>


### PR DESCRIPTION


**모집 마감일자, 여행 내용 필드 추가 및 동적 반영**
**참여 인원 수 표시 방식 수정(검색 페이지와 동일하게 하여 일관성 유지)**
**등록, 신청한 여행 초기 각 4개씩 로드 후 더 보기 버튼 클릭 시 추가 로드 기능 구현**

번외로, 검색 페이지에 태그 표기가 누락되길래 수정했읍니다
ㅅㄱㅇ