### PR TITLE
사용자 정보 수정 시 이미지 관련 로직 개선하였슨

### DIFF
--- a/src/main/java/com/wakutabi/controller/UserController.java
+++ b/src/main/java/com/wakutabi/controller/UserController.java
@@ -121,7 +121,12 @@ public class UserController {
     @PostMapping("/update")
     public String userInfoUpdate(
             UserUpdateDto user,
-            @RequestParam("profileImage") MultipartFile profileImage) throws IOException {
+            @RequestParam("profileImage") MultipartFile profileImage,
+            Principal principal) throws IOException {
+
+        // 현재 로그인된 사용자 정보 가져오기
+        String username = principal.getName();
+        UserUpdateDto currentUser = userService.getUserInfo(username);
 
         // --- 파일 처리 로직 시작 ---
         if (profileImage != null && !profileImage.isEmpty()) {
@@ -143,6 +148,9 @@ public class UserController {
             // 5. DB에는 웹 접근 경로를 저장합니다.
             // 예: "/upload/고유한이름_파일.jpg"
             user.setImagePath(webPath + storedFilename);
+        } else {
+            // 새 이미지가 업로드되지 않았다면 기존 이미지 경로 유지
+            user.setImagePath(currentUser.getImagePath());
         }
         // --- 파일 처리 로직 끝 ---
 

--- a/src/main/resources/templates/infos/info.html
+++ b/src/main/resources/templates/infos/info.html
@@ -35,7 +35,7 @@
                     <!-- 프로필 이미지 업로드 영역 -->
                     <div class="mb-4 text-center position-relative d-inline-block">
                         <!-- 이미지 태그 -->
-                        <img th:src="${user.imagePath != null and user.imagePath != '' ? user.imagePath : '/images/default.jpg'}" 
+                        <img th:src="${user.imagePath != null and user.imagePath != '' ? user.imagePath : '/image/member.png'}"
                             class="img-fluid rounded-circle profile-img mb-3" 
                             alt="프로필 이미지" >
                         <!-- 수정 버튼 (왼쪽 하단) -->

--- a/src/main/resources/templates/infos/info.html
+++ b/src/main/resources/templates/infos/info.html
@@ -4,96 +4,91 @@
   layout:decorate="~{/layouts/clean}">
 
 <head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>회원 정보 수정</title>
-<th:block layout:fragment="head">
-	<link rel="stylesheet" th:href="@{/css/mypage.css}">
-	<script defer src="/js/mypage.js"></script>
-</th:block>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>회원 정보 수정</title>
+    <th:block layout:fragment="head">
+        <link rel="stylesheet" th:href="@{/css/mypage.css}">
+        <script defer src="/js/mypage.js"></script>
+    </th:block>
 </head>
 
 <body>
 <div class="bg-gradient-custom2" layout:fragment="content">
-  <div class="container shadow p-4 bg-white rounded">
-    <div class="row">
-        <!-- 사이드메뉴 -->
-        <div class="col-md-3 border-end">
-            <h5 class="fw-bold mb-4">My page</h5>
-            <ul class="list-unstyled">
-                <li class="mb-3"><a href="/user/mypage" class="text-decoration-none text-dark">내 정보</a></li>
-                <li class="mb-3"><a href="/user/my-inquiries" class="text-decoration-none text-dark">내 문의 내역</a></li>
-                <li class="mb-3"><a href="/user/change-password" class="text-decoration-none text-dark">비밀번호 변경</a></li>
-                <li class="mb-3"><a href="/user/delete" class="text-decoration-none text-dark">회원 탈퇴</a></li>
-                <li class="mb-3"><a href="/" class="text-decoration-none text-dark">홈으로</a></li>
-            </ul>
-        </div>
-
-        <!-- 메인 컨텐츠 -->
-        <div class="col-md-9">
-            <form method="post" th:action="@{/user/update}" enctype="multipart/form-data">
-                <input type="hidden" name="id" th:value="${user.id}">
-                <!-- 프로필 이미지 업로드 영역 -->
-				<div class="mb-4 text-center position-relative d-inline-block">
-				    <!-- 이미지 태그 -->
-				    <img th:src="@{image/member.png}" 
-				         class="img-fluid rounded-circle profile-img mb-3" 
-				         alt="프로필 이미지" >
-				
-				    <!-- 수정 버튼 (왼쪽 하단) -->
-				    <label for="profileImage" 
-				           class="btn btn-sm btn-outline-secondary position-absolute">수정
-				    </label>
-
-				    <!-- 실제 파일 입력 요소 (숨김) -->
-				    <input type="file" name="profileImage" id="profileImage" class="d-none" accept="image/*">
-				</div>
-                <div class="mb-3">
-                    <label class="form-label fw-bold">이름</label>
-                    <input type="text" class="form-control" name="username" th:value="${user.username}" readonly>
-                </div>
-				<div class="mb-3">
-                    <label class="form-label fw-bold">닉네임</label>
-                    <input type="text" class="form-control" name="nickname" th:value="${user.nickname}" readonly>
-                </div>
-                <div class="mb-3">
-                    <label class="form-label fw-bold">이메일</label>
-                    <input type="email" class="form-control" name="email" th:value="${user.email}" value="user@example.com">
-                </div>
-                <div class="mb-3">
-                    <label class="form-label fw-bold" th:text="${userId}">생일 </label>
-                    <input type="date" class="form-control" name="birth" th:value="${user.birth}" value="1995-05-20">
-                </div>
-
-                <div class="mb-3">
-                    <label class="form-label fw-bold">성별</label>
-                    <select class="form-select" name="gender">
-                        <option th:value="${user.gender}" selected>선택해주세요</option>
-                        <option value="MALE">남성</option>
-                        <option value="FEMALE">여성</option>
-                        <option value="OTHER">기타</option>
-                        <option value="NONE">없음</option>
-                    </select>
-                </div>
-                <div class="mb-3">
-		            <label class="form-label fw-bold">프로필 공개 여부</label>
-		            <select class="form-select" name="isPublic">
-		             	<option value="true" selected>공개</option>
-		              	<option value="false">비공개</option>
-		            </select>
-		        </div>
-				<div class="mb-3">
-		           <label class="form-label fw-bold">자기소개</label>
-		           <textarea class="form-control" name="introduce" rows="4" placeholder="자기소개를 입력하세요." th:text="${user.introduce}">안녕하세요, 반갑습니다!</textarea>
-		        </div>
-		        
-                <div class="text-end">
-                    <button type="submit" class="btn btn-primary px-4">저장하기</button>
-                </div>
-            </form>
+    <div class="container shadow p-4 bg-white rounded">
+        <div class="row">
+            <!-- 사이드메뉴 -->
+            <div class="col-md-3 border-end">
+                <h5 class="fw-bold mb-4">My page</h5>
+                <ul class="list-unstyled">
+                    <li class="mb-3"><a href="/user/mypage" class="text-decoration-none text-dark">내 정보</a></li>
+                    <li class="mb-3"><a href="/user/my-inquiries" class="text-decoration-none text-dark">내 문의 내역</a></li>
+                    <li class="mb-3"><a href="/user/change-password" class="text-decoration-none text-dark">비밀번호 변경</a></li>
+                    <li class="mb-3"><a href="/user/delete" class="text-decoration-none text-dark">회원 탈퇴</a></li>
+                    <li class="mb-3"><a href="/" class="text-decoration-none text-dark">홈으로</a></li>
+                </ul>
+            </div>
+            <!-- 메인 컨텐츠 -->
+            <div class="col-md-9">
+                <form method="post" th:action="@{/user/update}" enctype="multipart/form-data">
+                    <input type="hidden" name="id" th:value="${user.id}">
+                    <!-- 프로필 이미지 업로드 영역 -->
+                    <div class="mb-4 text-center position-relative d-inline-block">
+                        <!-- 이미지 태그 -->
+                        <img th:src="${user.imagePath != null and user.imagePath != '' ? user.imagePath : '/images/default.jpg'}" 
+                            class="img-fluid rounded-circle profile-img mb-3" 
+                            alt="프로필 이미지" >
+                        <!-- 수정 버튼 (왼쪽 하단) -->
+                        <label for="profileImage" class="btn btn-sm btn-outline-secondary position-absolute">
+                            수정
+                        </label>
+                        <!-- 실제 파일 입력 요소 (숨김) -->
+                        <input type="file" name="profileImage" id="profileImage" class="d-none" accept="image/*">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">이름</label>
+                        <input type="text" class="form-control" name="username" th:value="${user.username}" readonly>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">닉네임</label>
+                        <input type="text" class="form-control" name="nickname" th:value="${user.nickname}" readonly>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">이메일</label>
+                        <input type="email" class="form-control" name="email" th:value="${user.email}" value="user@example.com">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-bold" th:text="${userId}">생일</label>
+                        <input type="date" class="form-control" name="birth" th:value="${user.birth}" value="1995-05-20">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">성별</label>
+                        <select class="form-select" name="gender">
+                            <option th:value="${user.gender}" selected>선택해주세요</option>
+                            <option value="MALE">남성</option>
+                            <option value="FEMALE">여성</option>
+                            <option value="OTHER">기타</option>
+                            <option value="NONE">없음</option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">프로필 공개 여부</label>
+                        <select class="form-select" name="isPublic">
+                            <option value="true" selected>공개</option>
+                            <option value="false">비공개</option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">자기소개</label>
+                        <textarea class="form-control" name="introduce" rows="4" placeholder="자기소개를 입력하세요." th:text="${user.introduce}">안녕하세요, 반갑습니다!</textarea>
+                    </div>
+                    <div class="text-end">
+                        <button type="submit" class="btn btn-primary px-4">저장하기</button>
+                    </div>
+                </form>
+            </div>
         </div>
     </div>
-</div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
1. 사용자가 프로필 이미지 등록했던 경우: 기존 이미지 불러오고 이미지 변경 없이 수정했음에도 기본 이미지로 초기화되던 문제 해결
2. 사용자가 프로필 이미지 미등록 했던 경우: 기본 이미지를 불러오게 되어있으나 정적 리소스 경로 오류 수정하여 깨진 채로 출력되던 문제 해결

테스트 ㄱㄱ